### PR TITLE
Add option to bundle issuer/intermediate CA together with the generated cert.

### DIFF
--- a/command/cert.go
+++ b/command/cert.go
@@ -18,6 +18,7 @@ type CertCommand struct {
 	Domains    []string `long:"domain" description:"Domains to be issued as Subject Alternative Names"`
 	CreateKey  bool     `long:"create-key" description:"Create a new keypair"`
 	RSAKeySize int      `long:"rsa-key-size" description:"Size of the RSA key, only used if create-key is specified. (allowed: 2048 / 4096)" default:"4096"`
+	BundleCA   bool     `long:"bundle-ca" description:"Bundle issuer CA certificate with the issued certificate"`
 }
 
 func (c *CertCommand) Execute(args []string) error {
@@ -32,6 +33,7 @@ func (c *CertCommand) Execute(args []string) error {
 		Domains:    c.Domains,
 		CreateKey:  c.CreateKey,
 		RSAKeySize: c.RSAKeySize,
+		BundleCA:   c.BundleCA,
 		Store:      store,
 	}).Run(context.Background())
 }
@@ -42,6 +44,7 @@ type CertService struct {
 	Domains    []string
 	CreateKey  bool
 	RSAKeySize int
+	BundleCA   bool
 	Store      *agent.Store
 }
 
@@ -103,6 +106,7 @@ func (svc *CertService) Run(ctx context.Context) error {
 	request := certificate.ObtainRequest{
 		Domains:    append([]string{svc.CommonName}, svc.Domains...),
 		PrivateKey: key,
+		Bundle:     svc.BundleCA,
 	}
 
 	cert, err := client.Certificate.Obtain(request)


### PR DESCRIPTION
## Overview
Discussed within team that it will be helpful if we can bundle the intermediate CA together, found that lego support that option.

## Changes
This PR extends lego's option to bundle issuer CA as a command line arg for `aaa`. 